### PR TITLE
Replace double quotes concatenation with template literals

### DIFF
--- a/zoomOnHover.js
+++ b/zoomOnHover.js
@@ -17,10 +17,12 @@ function pageOffset(el) {
 
 var zoomOnHover = {
 	props: ["imgNormal", "imgZoom", "scale", "disabled"],
-	template: "<div class=\"zoom-on-hover\" @mousemove=\"move\" @mouseenter=\"zoom\" @mouseleave=\"unzoom\">" +
-		"<img class=\"normal\" ref=\"normal\" :src=\"imgNormal\"/>" +
-		"<img class=\"zoom\" ref=\"zoom\" :src=\"imgZoom || imgNormal\"/>" +
-		"</div>",
+	template: `
+		<div class="zoom-on-hover" @mousemove="move" @mouseenter="zoom" @mouseleave="unzoom">
+			<img class="normal" ref="normal" :src="imgNormal"/> 
+			<img class="zoom" ref="zoom" :src="imgZoom || imgNormal"/> 
+		</div>
+	`,
 	data: function () {
 		return {
 			scaleFactor: 1,


### PR DESCRIPTION
Template literals are easy for reading and can handle multi-line strings well instead of escaping and concatenating double quotes.